### PR TITLE
feat: support pixi's pyproject.toml (#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ A VS Code extension for checking the latest version of each dependency.
 
 ### Python
 
-| Format                                                                                                                                                    | Private Source                              |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `requirements.txt`                                                                                                                                        | `--index-url` is supported                  |
-| `pyproject.toml` ([Poetry](https://python-poetry.org/) and pip's [pyproject.toml](https://packaging.python.org/en/latest/specifications/pyproject-toml/)) | Poetry's `tool.poetry.source` is supported. |
+| Format                                                                                                                                                                              | Private Source                              |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `requirements.txt`                                                                                                                                                                  | `--index-url` is supported                  |
+| `pyproject.toml` ([Poetry](https://python-poetry.org/), [Pixi](https://pixi.sh/) and pip's [pyproject.toml](https://packaging.python.org/en/latest/specifications/pyproject-toml/)) | Poetry's `tool.poetry.source` is supported. |
 
 #### Known Limitations
 

--- a/src/format/pixi.spec.ts
+++ b/src/format/pixi.spec.ts
@@ -1,0 +1,20 @@
+import { createProject } from "./pixi";
+
+const text = `[project]
+name = "pixi-py"
+version = "0.1.0"
+requires-python = ">= 3.11"
+
+[tool.pixi.dependencies]
+black = ">=24.4.2,<25"
+fastapi = ">=0.112.0,<0.113"
+
+[tool.pixi.feature.test.dependencies]
+pytest = "*"`;
+
+describe("createPythonProject", () => {
+  test("should return a project", () => {
+    const project = createProject(text);
+    expect(project.dependencies).toEqual(["black", "fastapi", "pytest"]);
+  });
+});

--- a/src/format/pixi.ts
+++ b/src/format/pixi.ts
@@ -1,0 +1,21 @@
+import TOML from "@iarna/toml";
+import { flat } from "radash";
+
+import { PixiProjectSchema, ProjectType } from "@/schemas";
+
+export function getDependenciesFrom(text: string): string[] {
+  const tomlParsed = TOML.parse(text);
+  const parsed = PixiProjectSchema.parse(tomlParsed);
+
+  return flat([
+    Object.keys(parsed.tool.pixi.dependencies),
+    Object.keys(parsed.tool.pixi.feature).flatMap((feature) =>
+      Object.keys(parsed.tool.pixi.feature[feature].dependencies),
+    ),
+  ]);
+}
+
+export function createProject(text: string): ProjectType {
+  const dependencies = getDependenciesFrom(text);
+  return { dependencies, format: "pixi" };
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -78,7 +78,7 @@ export const PoetryProjectPoetrySourceSchema = z.object({
   url: z.string(),
 });
 
-export const PoetryProjectPoetryGroupDependenciesSchema = z.object({
+export const GroupDependenciesSchema = z.object({
   dependencies: z.record(z.string(), z.unknown()).default({}),
 });
 
@@ -88,9 +88,7 @@ export const PoetryProjectPoetrySchema = z.object({
   source: z.array(PoetryProjectPoetrySourceSchema).nullish(),
   dependencies: z.record(z.string(), z.unknown()).default({}),
   "dev-dependencies": z.record(z.string(), z.unknown()).default({}),
-  group: z
-    .record(z.string(), PoetryProjectPoetryGroupDependenciesSchema)
-    .default({}),
+  group: z.record(z.string(), GroupDependenciesSchema).default({}),
 });
 
 export const PoetryProjectToolSchema = z.object({
@@ -110,13 +108,27 @@ export const PyProjectSchema = z.object({
   project: PyProjectProjectSchema,
 });
 
+export const PixiToolPixiSchema = z.object({
+  dependencies: z.record(z.string(), z.unknown()).default({}),
+  feature: z.record(z.string(), GroupDependenciesSchema).default({}),
+});
+
+export const PixiToolSchema = z.object({
+  pixi: PixiToolPixiSchema,
+});
+
+export const PixiProjectSchema = z.object({
+  tool: PixiToolSchema,
+});
+
 export const ProjectFormatSchema = z.enum([
+  "actions",
+  "gemfile",
+  "gemspec",
+  "pixi",
   "poetry",
   "pyproject",
   "requirements",
-  "gemspec",
-  "gemfile",
-  "actions",
 ]);
 export type ProjectFormatType = z.infer<typeof ProjectFormatSchema>;
 


### PR DESCRIPTION
Support Pixi's `pyproject.toml`. (#75)

I must confess that I don't completely understand Pixi's `pyproject.toml` schema. But I think this implementation covers 90+% cases. 

Note: I tested this implementation with https://github.com/skrub-data/skrub/blob/main/pyproject.toml and it works fine.

![Screenshot 2024-08-03 at 9 06 17](https://github.com/user-attachments/assets/0f3d6db2-e1e3-4e8c-a679-5f4176aacba0)

 