### PR TITLE
fix: use smol-toml to fix #94

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "vscode-mogami",
       "version": "0.0.0",
       "dependencies": {
-        "@iarna/toml": "^2.2.5",
         "@renovatebot/pep440": "^3.0.20",
         "@renovatebot/ruby-semver": "^3.0.23",
         "axios": "^1.7.7",
@@ -20,6 +19,7 @@
         "p-map": "^7.0.2",
         "radash": "^12.1.0",
         "semver": "^7.6.3",
+        "smol-toml": "^1.3.0",
         "url-join": "^5.0.0",
         "winston-transport-vscode": "^0.1.0",
         "zod": "^3.23.8"
@@ -1416,12 +1416,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
-    },
-    "node_modules/@iarna/toml": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
-      "license": "ISC"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -10750,6 +10744,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.0.tgz",
+      "integrity": "sha512-tWpi2TsODPScmi48b/OQZGi2lgUmBCHy6SZrhi/FdnnHiU1GwebbCfuQuxsC3nHaLwtYeJGPrDZDIeodDOc4pA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",
+    "@ninoseki/eslint-plugin-neverthrow": "^0.0.1",
     "@types/eslint__js": "^8.42.3",
     "@types/iarna__toml": "^2.0.5",
     "@types/jest": "^29.5.14",
@@ -141,7 +142,6 @@
     "@vscode/vsce": "^3.2.1",
     "eslint": "^9.14.0",
     "eslint-plugin-jest": "^28.8.3",
-    "@ninoseki/eslint-plugin-neverthrow": "^0.0.1",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-regexp": "^2.6.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -157,7 +157,6 @@
     "typescript-eslint": "^8.12.2"
   },
   "dependencies": {
-    "@iarna/toml": "^2.2.5",
     "@renovatebot/pep440": "^3.0.20",
     "@renovatebot/ruby-semver": "^3.0.23",
     "axios": "^1.7.7",
@@ -169,6 +168,7 @@
     "p-map": "^7.0.2",
     "radash": "^12.1.0",
     "semver": "^7.6.3",
+    "smol-toml": "^1.3.0",
     "url-join": "^5.0.0",
     "winston-transport-vscode": "^0.1.0",
     "zod": "^3.23.8"

--- a/src/project/pixi.ts
+++ b/src/project/pixi.ts
@@ -1,13 +1,12 @@
-import TOML from "@iarna/toml";
 import { flat } from "radash";
+import { parse } from "smol-toml";
 
 import { PixiProjectSchema, ProjectType } from "@/schemas";
 
 import { createRegex } from "./pypi";
 
 export function getDependenciesFrom(text: string): string[] {
-  const tomlParsed = TOML.parse(text);
-  const parsed = PixiProjectSchema.parse(tomlParsed);
+  const parsed = PixiProjectSchema.parse(parse(text));
 
   return flat([
     Object.keys(parsed.tool.pixi.dependencies),

--- a/src/project/poetry.ts
+++ b/src/project/poetry.ts
@@ -1,12 +1,12 @@
-import TOML from "@iarna/toml";
 import { flat } from "radash";
+import { parse } from "smol-toml";
 
 import { PoetryProjectSchema, type ProjectType } from "@/schemas";
 
 import { createRegex } from "./pypi";
 
 export function createProject(text: string): ProjectType {
-  const parsed = PoetryProjectSchema.parse(TOML.parse(text));
+  const parsed = PoetryProjectSchema.parse(parse(text));
 
   const format = "poetry";
   const source = (parsed.tool.poetry?.source || [])

--- a/src/project/pyproject.ts
+++ b/src/project/pyproject.ts
@@ -1,5 +1,5 @@
-import TOML from "@iarna/toml";
 import camelcaseKeys from "camelcase-keys";
+import { parse } from "smol-toml";
 
 import { ProjectType, PyProjectSchema } from "@/schemas";
 
@@ -7,9 +7,8 @@ import { createRegex } from "./pypi";
 import { parse as pipParse } from "./requirements";
 
 export function getDependenciesFrom(text: string): string[] {
-  const tomlParsed = TOML.parse(text);
   const parsed = PyProjectSchema.parse(
-    camelcaseKeys(tomlParsed, { deep: true }),
+    camelcaseKeys(parse(text), { deep: true }),
   );
 
   const dependencies = parsed.project.dependencies || [];

--- a/src/project/uv.spec.ts
+++ b/src/project/uv.spec.ts
@@ -15,6 +15,7 @@ foo = ["mkdocs>=1.6.0"]
 
 [dependency-groups]
 test = ["coverage"]
+all = [{include-group = "test"}]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/project/uv.ts
+++ b/src/project/uv.ts
@@ -1,5 +1,5 @@
-import TOML from "@iarna/toml";
 import camelcaseKeys from "camelcase-keys";
+import { parse } from "smol-toml";
 
 import { ProjectType, UvProjectSchema, UvProjectType } from "@/schemas";
 
@@ -7,8 +7,7 @@ import { createRegex } from "./pypi";
 import { parse as pipParse } from "./requirements";
 
 function parseAsProject(text: string) {
-  const tomlParsed = TOML.parse(text);
-  return UvProjectSchema.parse(camelcaseKeys(tomlParsed, { deep: true }));
+  return UvProjectSchema.parse(camelcaseKeys(parse(text), { deep: true }));
 }
 
 export function getDependenciesFrom(parsed: UvProjectType): string[] {
@@ -16,9 +15,9 @@ export function getDependenciesFrom(parsed: UvProjectType): string[] {
   const optionalDependencies = Object.values(
     parsed.project.optionalDependencies || {},
   ).flat();
-  const groupsDependencies = Object.values(
-    parsed.dependencyGroups || {},
-  ).flat();
+  const groupsDependencies = Object.values(parsed.dependencyGroups || {})
+    .flat()
+    .filter((i): i is string => typeof i === "string");
   const devDependencies = parsed.tool?.uv?.devDependencies || [];
 
   return [

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -150,7 +150,9 @@ export const UvProjectSchema = z.object({
   project: UvProjectProjectSchema,
   tool: UvProjectToolSchema.nullish(),
   // PEP 735 (ref. https://github.com/astral-sh/uv/releases/tag/0.4.27)
-  dependencyGroups: z.record(z.string(), z.array(z.string())).nullish(),
+  dependencyGroups: z
+    .record(z.string(), z.union([z.array(z.string()), z.unknown()]))
+    .nullish(),
 });
 
 export type UvProjectType = z.infer<typeof UvProjectSchema>;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   clean: true,
   external: ["vscode"],
   noExternal: [
-    "@iarna/toml",
     "@renovatebot/pep440",
     "@renovatebot/ruby-semver",
     "axios-cache-interceptor",
@@ -20,6 +19,7 @@ export default defineConfig({
     "p-map",
     "radash",
     "semver",
+    "smol-toml",
     "url-join",
     "winston-transport-vscode",
     "zod",


### PR DESCRIPTION
Use smol-toml instead of `@iarna/toml` to fix #94 & update Zod schema to support `include-group` in `dependency-groups` (see PEP 735 for details).