### PR TITLE
feat: support format specific validRange

### DIFF
--- a/src/codeLens/utils.spec.ts
+++ b/src/codeLens/utils.spec.ts
@@ -1,0 +1,109 @@
+import * as E from "fp-ts/lib/Either";
+
+import { DependencyType, PackageType, SatisfiesFnType } from "@/schemas";
+import { satisfies, validRange } from "@/versioning/utils";
+
+import { createPackageSuggestions, PackageSuggestion } from "./utils";
+
+describe("createPackageSuggestions", () => {
+  test.each([
+    // latest & fixed specifier
+    [
+      { name: "foo", specifier: "1.0.0" } as DependencyType,
+      { name: "foo", version: "1.0.0", versions: ["1.0.0"] } as PackageType,
+      satisfies,
+      [{ title: "🟢 latest 1.0.0", command: "" }] as PackageSuggestion[],
+    ],
+    // outdated & fixed specifier
+    [
+      { name: "foo", specifier: "1.0.0" } as DependencyType,
+      { name: "foo", version: "2.0.0", versions: ["2.0.0"] } as PackageType,
+      satisfies,
+      [
+        { title: "🟡 fixed 1.0.0", command: "" },
+        {
+          command: "vscode-mogami.suggestions.updateDependencyClick",
+          replaceable: true,
+          title: "↑ latest 2.0.0",
+        },
+      ] as PackageSuggestion[],
+    ],
+    // outdated & range specifier (satisfies)
+    [
+      { name: "foo", specifier: ">=1.0.0" } as DependencyType,
+      {
+        name: "foo",
+        version: "2.0.0",
+        versions: ["2.0.0", "1.0.0"],
+      } as PackageType,
+      satisfies,
+      [
+        {
+          command: "",
+          title: "🟡 satisfies latest 2.0.0",
+        },
+        {
+          command: "vscode-mogami.suggestions.updateDependencyClick",
+          replaceable: true,
+          title: "↑ latest 2.0.0",
+        },
+      ] as PackageSuggestion[],
+    ],
+    // outdated & range specifier (un-satisfies)
+    [
+      { name: "foo", specifier: ">=1.0.0,<2.0.0" } as DependencyType,
+      {
+        name: "foo",
+        version: "2.0.0",
+        versions: ["2.0.0", "1.0.0"],
+      } as PackageType,
+      satisfies,
+      [
+        {
+          command: "vscode-mogami.suggestions.updateDependencyClick",
+          replaceable: true,
+          title: "↑ latest 2.0.0",
+        },
+      ] as PackageSuggestion[],
+    ],
+    // outdated & range specifier (un-satisfies & has newer version)
+    [
+      { name: "foo", specifier: ">=1.0.0 <2.0.0" } as DependencyType,
+      {
+        name: "foo",
+        version: "2.0.0",
+        versions: ["2.0.0", "1.1.0", "1.0.0"],
+      } as PackageType,
+      satisfies,
+      [
+        {
+          command: "",
+          title: "🟡 satisfies 1.1.0",
+        },
+        {
+          command: "vscode-mogami.suggestions.updateDependencyClick",
+          replaceable: true,
+          title: "↑ latest 2.0.0",
+        },
+      ] as PackageSuggestion[],
+    ],
+  ])(
+    "createPackageSuggestions(%s, %s, %s) === %s",
+    (
+      dependency: DependencyType,
+      pkg: PackageType,
+      satisfies: SatisfiesFnType,
+      expected: PackageSuggestion[],
+    ) => {
+      const pkgResult = E.right(pkg);
+      expect(
+        createPackageSuggestions({
+          dependency,
+          pkgResult,
+          satisfies,
+          validRange,
+        }),
+      ).toEqual(expected);
+    },
+  );
+});

--- a/src/codeLens/utils.ts
+++ b/src/codeLens/utils.ts
@@ -1,0 +1,115 @@
+// split from codeLensFactory.ts to make them testable
+// (using "vscode" package makes it difficult to test with vitest)
+import { isAxiosError } from "axios";
+import * as E from "fp-ts/lib/Either";
+import semver from "semver";
+
+import { OnUpdateDependencyClickCommand } from "@/constants";
+import type {
+  DependencyType,
+  PackageType,
+  SatisfiesFnType,
+  ValidRangeFnType,
+} from "@/schemas";
+import { eq, maxSatisfying } from "@/versioning/utils";
+
+export interface PackageSuggestion {
+  title: string;
+  command: string;
+  replaceable?: boolean;
+}
+
+function createErrorSuggestion(err: unknown): PackageSuggestion {
+  const symbol = "🔴";
+  const message: string = (() => {
+    if (isAxiosError(err)) {
+      switch (err.response?.status) {
+        case 400:
+          return `400 bad request`;
+        case 401:
+          return `401 not authorized`;
+        case 403:
+          return `403 forbidden`;
+        case 404:
+          return `package not found`;
+        case 500:
+          return `internal server error`;
+      }
+    }
+    return `something went wrong`;
+  })();
+  return {
+    title: `${symbol} ${message}`,
+    command: "",
+  };
+}
+
+function createFixedSuggestion(dependency: DependencyType): PackageSuggestion {
+  return { title: `🟡 fixed ${dependency.specifier}`, command: "" };
+}
+
+function createLatestSuggestion(pkg: PackageType): PackageSuggestion {
+  return { title: `🟢 latest ${pkg.version}`, command: "" };
+}
+
+function createLatestSatisfiesSuggestion(pkg: PackageType): PackageSuggestion {
+  return { title: `🟡 satisfies latest ${pkg.version}`, command: "" };
+}
+
+function createSatisfiesSuggestion(
+  satisfiesVersion: string,
+): PackageSuggestion {
+  return { title: `🟡 satisfies ${satisfiesVersion}`, command: "" };
+}
+
+function createUpdatableSuggestion(pkg: PackageType): PackageSuggestion {
+  const title = `↑ latest ${pkg.version}`;
+  return { title, command: OnUpdateDependencyClickCommand, replaceable: true };
+}
+
+export function createPackageSuggestions({
+  dependency,
+  pkgResult,
+  satisfies,
+  validRange,
+}: {
+  dependency: DependencyType;
+  pkgResult: E.Either<unknown, PackageType>;
+  satisfies: SatisfiesFnType;
+  validRange: ValidRangeFnType;
+}): PackageSuggestion[] {
+  if (E.isLeft(pkgResult)) {
+    return [createErrorSuggestion(pkgResult.left)];
+  }
+
+  const suggestions: PackageSuggestion[] = [];
+  const pkg = pkgResult.right;
+
+  const isLatest: boolean =
+    eq(pkg.version, dependency.specifier) || !dependency.specifier;
+  const isFixedSpecifier: boolean = semver.valid(dependency.specifier) !== null;
+  const isRangeSpecifier: boolean = validRange(dependency.specifier);
+  const satisfiesVersion = maxSatisfying({
+    pkg,
+    specifier: dependency.specifier,
+    satisfies,
+  });
+
+  if (isLatest) {
+    suggestions.push(createLatestSuggestion(pkg));
+  } else if (isFixedSpecifier) {
+    suggestions.push(createFixedSuggestion(dependency));
+  } else if (isRangeSpecifier && satisfiesVersion) {
+    if (satisfiesVersion === pkg.version) {
+      suggestions.push(createLatestSatisfiesSuggestion(pkg));
+    } else {
+      suggestions.push(createSatisfiesSuggestion(satisfiesVersion));
+    }
+  }
+
+  if (!isLatest) {
+    suggestions.push(createUpdatableSuggestion(pkg));
+  }
+
+  return suggestions;
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -124,6 +124,8 @@ export interface CodeLensType {
 
 export type SatisfiesFnType = (version: string, specifier?: string) => boolean;
 
+export type ValidRangeFnType = (specifier?: string) => boolean;
+
 export interface PackageClientType {
   get: (name: string) => Promise<PackageType>;
   clearCache: () => void;

--- a/src/versioning/pypi.spec.ts
+++ b/src/versioning/pypi.spec.ts
@@ -1,4 +1,4 @@
-import { satisfies } from "./pypi";
+import { satisfies, validRange } from "./pypi";
 
 describe("satisfies", () => {
   test.each([
@@ -16,6 +16,25 @@ describe("satisfies", () => {
     "satisfies(%s, %s) === %s",
     (version: string, specifier: string, expected: boolean) => {
       expect(satisfies(version, specifier)).toBe(expected);
+    },
+  );
+});
+
+describe("validRange", () => {
+  test.each([
+    [undefined, false],
+    ["1.0.0", false],
+    ["==1.0.0", false],
+    [">=1.0.0", true],
+    ["~=1.0.0", true],
+    [">=1.0.0,<2.0.0", true],
+    ["!=1.0.0", true],
+    // invalid ranged version specifier
+    [">=1.0.0 <2.0.0", false],
+  ])(
+    "validRange(%s) === %s",
+    (specifier: string | undefined, expected: boolean) => {
+      expect(validRange(specifier)).toBe(expected);
     },
   );
 });

--- a/src/versioning/pypi.ts
+++ b/src/versioning/pypi.ts
@@ -1,4 +1,5 @@
 import { satisfies as pep440Satisfies } from "@renovatebot/pep440";
+import { parse } from "@renovatebot/pep440/lib/specifier";
 import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/Option";
 import semver from "semver";
@@ -17,5 +18,22 @@ export function satisfies(version: string, specifier?: string): boolean {
   return (
     pep440Satisfies(coercedVersion, specifier) ||
     semver.satisfies(coercedVersion, specifier)
+  );
+}
+
+const isStrictEqualityOperator = (op: string) => ["==", "==="].includes(op);
+
+export function validRange(specifier?: string): boolean {
+  if (!specifier) {
+    return false;
+  }
+
+  const constraints = parse(specifier);
+  if (constraints === null) {
+    return false;
+  }
+
+  return constraints.every(
+    (constraint) => !isStrictEqualityOperator(constraint.operator),
   );
 }

--- a/src/versioning/utils.ts
+++ b/src/versioning/utils.ts
@@ -165,3 +165,7 @@ export function isPrerelease(v: string): boolean {
   }
   return !/^\d[.\d]+$/.test(v);
 }
+
+export function validRange(specifier?: string): boolean {
+  return semver.validRange(specifier) !== null;
+}


### PR DESCRIPTION
`semver.validRange` does not work along with PyPI's version specifier. For example, `>=1.0,<2.0` does not work. (`>=1.0 <2.0` works but)
So format specific `validRange` is needed. 