### PR TITLE
fix: handle prerelease only package

### DIFF
--- a/src/codeLens/utils.ts
+++ b/src/codeLens/utils.ts
@@ -36,6 +36,9 @@ function createErrorSuggestion(err: unknown): PackageSuggestion {
           return `internal server error`;
       }
     }
+    if (err instanceof Error) {
+      return err.message;
+    }
     return `something went wrong`;
   })();
   return {

--- a/src/package/abstractClient.ts
+++ b/src/package/abstractClient.ts
@@ -45,6 +45,11 @@ export abstract class AbstractPackageClient implements PackageClientType {
     const versions = this.showPrerelease
       ? pkg.versions
       : pkg.versions.filter((v) => !isPrerelease(v));
+
+    if (versions.length === 0) {
+      throw new Error("No valid versions found");
+    }
+
     const sortedVersions = versions.sort(compare);
     pkg.version = sortedVersions[sortedVersions.length - 1];
     return pkg;

--- a/src/package/pypi.ts
+++ b/src/package/pypi.ts
@@ -4,6 +4,7 @@ import { parseHTML } from "linkedom";
 import { unique } from "radash";
 import semver from "semver";
 import urlJoin from "url-join";
+import { ZodError } from "zod";
 
 import { PackageType, PypiPackageSchema } from "@/schemas";
 import { compare } from "@/versioning/utils";
@@ -100,8 +101,14 @@ export class PyPIClient extends AbstractPackageClient {
     try {
       const result = parse(res);
       return this.normalizePackage(result);
-    } catch {
-      // continue to simple parser
+    } catch (err) {
+      // if it's zod error, try simple parse
+      if (err instanceof ZodError) {
+        // continue to simple parse
+      } else {
+        // throw logic error
+        throw err;
+      }
     }
 
     try {


### PR DESCRIPTION
Fix #143 by showing an error message when a package only has prerelease versions & showPrerelease is set as false.