### PR TITLE
fix: Fix resolution of GitHub Actions with multiple slashes

### DIFF
--- a/src/package/github.spec.ts
+++ b/src/package/github.spec.ts
@@ -16,7 +16,7 @@ function mockFetchSequence(...bodies: unknown[]) {
       headers: new Headers(),
       json: () => Promise.resolve(body),
       text: () => Promise.resolve(JSON.stringify(body)),
-    })
+    } as Response)
   }
   vi.stubGlobal('fetch', fetchMock)
   return fetchMock

--- a/src/package/github.spec.ts
+++ b/src/package/github.spec.ts
@@ -1,0 +1,78 @@
+import { clearCache } from './cache'
+import { GitHubClient } from './github'
+
+vi.mock('@/configuration', () => ({
+  getShowPrerelease: () => false,
+  getUsePrivateSource: () => false,
+}))
+
+function mockFetchSequence(...bodies: unknown[]) {
+  const fetchMock = vi.fn<typeof fetch>()
+  for (const body of bodies) {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(JSON.stringify(body)),
+    })
+  }
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('GitHubClient', () => {
+  beforeEach(() => {
+    clearCache()
+    vi.unstubAllGlobals()
+  })
+
+  it('fetches release and tag for a simple owner/repo action', async () => {
+    const fetchMock = mockFetchSequence(
+      { tag_name: 'v4' },
+      { object: { sha: 'abc123' } },
+    )
+
+    const client = new GitHubClient()
+    const pkg = await client.get('actions/checkout')
+
+    expect(pkg).toEqual({
+      name: 'actions/checkout',
+      version: 'v4',
+      versions: ['v4'],
+      alias: 'abc123',
+      format: 'github-actions-workflow',
+    })
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.github.com/repos/actions/checkout/releases/latest',
+    )
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.github.com/repos/actions/checkout/git/refs/tags/v4',
+    )
+  })
+
+  it('uses only owner/repo when the action references a sub-path', async () => {
+    const fetchMock = mockFetchSequence(
+      { tag_name: 'v4' },
+      { object: { sha: 'def456' } },
+    )
+
+    const client = new GitHubClient()
+    const pkg = await client.get('github/codeql-action/init')
+
+    expect(pkg).toEqual({
+      name: 'github/codeql-action/init',
+      version: 'v4',
+      versions: ['v4'],
+      alias: 'def456',
+      format: 'github-actions-workflow',
+    })
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.github.com/repos/github/codeql-action/releases/latest',
+    )
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.github.com/repos/github/codeql-action/git/refs/tags/v4',
+    )
+  })
+})

--- a/src/package/github.ts
+++ b/src/package/github.ts
@@ -43,9 +43,14 @@ export class GitHubClient extends AbstractPackageClient {
       headers.authorization = `Bearer ${this.gitHubPersonalAccessToken}`
     }
 
+    // GitHub Actions can reference a sub-path within a repository
+    // (e.g. `github/codeql-action/init`), but the GitHub API only accepts
+    // the `owner/repo` portion.
+    const repo = name.split('/').slice(0, 2).join('/')
+
     const getLatestRelease = async () => {
       const data = await this.fetchJson(
-        urlJoin(this.source.toString(), 'repos', name, 'releases', 'latest'),
+        urlJoin(this.source.toString(), 'repos', repo, 'releases', 'latest'),
         { headers },
       )
       return GitHubReleaseSchema.parse(camelcaseKeys(data as object, { deep: true }))
@@ -53,7 +58,7 @@ export class GitHubClient extends AbstractPackageClient {
 
     const getTag = async (tagName: string) => {
       const data = await this.fetchJson(
-        urlJoin(this.source.toString(), 'repos', name, 'git', 'refs', 'tags', tagName),
+        urlJoin(this.source.toString(), 'repos', repo, 'git', 'refs', 'tags', tagName),
         { headers },
       )
       return GitHubTagSchema.parse(data)


### PR DESCRIPTION
AI Disclosure: This was generated using Claude Code to fix the issue and generated the test, it was tested manually by me to ensure the fix worked, and the code has been reviewed by me.

GitHub Actions (such as codeql) can be a "bundle" where they all come from one repo but have "sub-actions" available.

The test is mostly mocked-out, so it may not be very useful and I can remove it if preferred.

Fixes #179.

Before:

<img width="731" height="131" alt="Screenshot 2026-05-07 at 7 11 15 PM" src="https://github.com/user-attachments/assets/cfb383e5-8cab-483e-8bc1-30d944351e59" />

After:

<img width="903" height="67" alt="Screenshot 2026-05-07 at 7 19 19 PM" src="https://github.com/user-attachments/assets/d685c91d-c362-407b-9356-b9621179347e" />

<img width="426" height="51" alt="Screenshot 2026-05-07 at 7 19 21 PM" src="https://github.com/user-attachments/assets/f7659bcf-79ae-4645-949a-3d999fdf7e29" />