### PR TITLE
Use list releases API

### DIFF
--- a/src/package/abstractClient.ts
+++ b/src/package/abstractClient.ts
@@ -11,7 +11,7 @@ const DEFAULT_TIMEOUT_MS = 30_000
 
 export abstract class AbstractPackageClient implements PackageClientType {
   private usePrivateSource: boolean
-  private showPrerelease: boolean
+  protected showPrerelease: boolean
   private primarySource: URL
   private privateSource?: URL
 

--- a/src/package/github.spec.ts
+++ b/src/package/github.spec.ts
@@ -29,9 +29,16 @@ describe('GitHubClient', () => {
   })
 
   it('picks the highest released version and resolves its tag SHA', async () => {
-    const fetchMock = mockFetchSequence([{ name: 'v2' }, { name: 'v4' }, { name: 'v3' }], {
-      object: { sha: 'abc123' },
-    })
+    const fetchMock = mockFetchSequence(
+      [
+        { tag_name: 'v2', prerelease: false },
+        { tag_name: 'v4', prerelease: false },
+        { tag_name: 'v3', prerelease: false },
+      ],
+      {
+        sha: 'abc123',
+      },
+    )
 
     const client = new GitHubClient()
     const pkg = await client.get('actions/checkout')
@@ -53,7 +60,7 @@ describe('GitHubClient', () => {
   })
 
   it('uses only owner/repo when the action references a sub-path', async () => {
-    const fetchMock = mockFetchSequence([{ name: 'v4', prerelease: false }], { sha: 'def456' })
+    const fetchMock = mockFetchSequence([{ tag_name: 'v4', prerelease: false }], { sha: 'def456' })
 
     const client = new GitHubClient()
     const pkg = await client.get('github/codeql-action/init')
@@ -80,10 +87,10 @@ describe('GitHubClient', () => {
     // action version.
     mockFetchSequence(
       [
-        { name: 'codeql-bundle-v2.25.4', prerelease: false },
-        { name: 'v4.35.4', prerelease: false },
-        { name: 'v4.35.3', prerelease: false },
-        { name: 'v3.29.0', prerelease: false },
+        { tag_name: 'codeql-bundle-v2.25.4', prerelease: false },
+        { tag_name: 'v4.35.4', prerelease: false },
+        { tag_name: 'v4.35.3', prerelease: false },
+        { tag_name: 'v3.29.0', prerelease: false },
       ],
       { sha: 'v4354sha' },
     )

--- a/src/package/github.spec.ts
+++ b/src/package/github.spec.ts
@@ -48,12 +48,12 @@ describe('GitHubClient', () => {
       'https://api.github.com/repos/actions/checkout/releases',
     )
     expect(fetchMock.mock.calls[1][0]).toBe(
-      'https://api.github.com/repos/actions/checkout/git/refs/tags/v4',
+      'https://api.github.com/repos/actions/checkout/commits/v4',
     )
   })
 
   it('uses only owner/repo when the action references a sub-path', async () => {
-    const fetchMock = mockFetchSequence([{ name: 'v4' }], { object: { sha: 'def456' } })
+    const fetchMock = mockFetchSequence([{ name: 'v4', prerelease: false }], { sha: 'def456' })
 
     const client = new GitHubClient()
     const pkg = await client.get('github/codeql-action/init')
@@ -69,7 +69,7 @@ describe('GitHubClient', () => {
       'https://api.github.com/repos/github/codeql-action/releases',
     )
     expect(fetchMock.mock.calls[1][0]).toBe(
-      'https://api.github.com/repos/github/codeql-action/git/refs/tags/v4',
+      'https://api.github.com/repos/github/codeql-action/commits/v4',
     )
   })
 
@@ -80,12 +80,12 @@ describe('GitHubClient', () => {
     // action version.
     mockFetchSequence(
       [
-        { name: 'codeql-bundle-v2.25.4' },
-        { name: 'v4.35.4' },
-        { name: 'v4.35.3' },
-        { name: 'v3.29.0' },
+        { name: 'codeql-bundle-v2.25.4', prerelease: false },
+        { name: 'v4.35.4', prerelease: false },
+        { name: 'v4.35.3', prerelease: false },
+        { name: 'v3.29.0', prerelease: false },
       ],
-      { object: { sha: 'v4354sha' } },
+      { sha: 'v4354sha' },
     )
 
     const client = new GitHubClient()

--- a/src/package/github.spec.ts
+++ b/src/package/github.spec.ts
@@ -28,11 +28,10 @@ describe('GitHubClient', () => {
     vi.unstubAllGlobals()
   })
 
-  it('fetches release and tag for a simple owner/repo action', async () => {
-    const fetchMock = mockFetchSequence(
-      { tag_name: 'v4' },
-      { object: { sha: 'abc123' } },
-    )
+  it('picks the highest released version and resolves its tag SHA', async () => {
+    const fetchMock = mockFetchSequence([{ name: 'v2' }, { name: 'v4' }, { name: 'v3' }], {
+      object: { sha: 'abc123' },
+    })
 
     const client = new GitHubClient()
     const pkg = await client.get('actions/checkout')
@@ -44,8 +43,9 @@ describe('GitHubClient', () => {
       alias: 'abc123',
       format: 'github-actions-workflow',
     })
+    expect(fetchMock.mock.calls).toHaveLength(2)
     expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://api.github.com/repos/actions/checkout/releases/latest',
+      'https://api.github.com/repos/actions/checkout/releases',
     )
     expect(fetchMock.mock.calls[1][0]).toBe(
       'https://api.github.com/repos/actions/checkout/git/refs/tags/v4',
@@ -53,10 +53,7 @@ describe('GitHubClient', () => {
   })
 
   it('uses only owner/repo when the action references a sub-path', async () => {
-    const fetchMock = mockFetchSequence(
-      { tag_name: 'v4' },
-      { object: { sha: 'def456' } },
-    )
+    const fetchMock = mockFetchSequence([{ name: 'v4' }], { object: { sha: 'def456' } })
 
     const client = new GitHubClient()
     const pkg = await client.get('github/codeql-action/init')
@@ -69,10 +66,32 @@ describe('GitHubClient', () => {
       format: 'github-actions-workflow',
     })
     expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://api.github.com/repos/github/codeql-action/releases/latest',
+      'https://api.github.com/repos/github/codeql-action/releases',
     )
     expect(fetchMock.mock.calls[1][0]).toBe(
       'https://api.github.com/repos/github/codeql-action/git/refs/tags/v4',
     )
+  })
+
+  it('ignores release lines that are not action versions (codeql-action)', async () => {
+    // Mirrors github/codeql-action's release list: action releases (vX.Y.Z)
+    // coexist with parallel codeql-bundle-* releases. The "latest release"
+    // endpoint may surface the bundle, but listing+sorting picks the highest
+    // action version.
+    mockFetchSequence(
+      [
+        { name: 'codeql-bundle-v2.25.4' },
+        { name: 'v4.35.4' },
+        { name: 'v4.35.3' },
+        { name: 'v3.29.0' },
+      ],
+      { object: { sha: 'v4354sha' } },
+    )
+
+    const client = new GitHubClient()
+    const pkg = await client.get('github/codeql-action/init')
+
+    expect(pkg.version).toBe('v4.35.4')
+    expect(pkg.alias).toBe('v4354sha')
   })
 })

--- a/src/package/github.ts
+++ b/src/package/github.ts
@@ -2,20 +2,17 @@ import z from 'zod'
 
 import { PackageType } from '@/schemas'
 import { urlJoin } from '@/utils'
-import { coerceUnlessValid, compare, isPrerelease } from '@/versioning/utils'
+import { compare } from '@/versioning/utils'
 
 import { AbstractPackageClient } from './abstractClient'
 
-const GitHubTagObjectSchema = z.object({
+export const GitHubCommitSchema = z.object({
   sha: z.string(),
 })
 
-export const GitHubTagSchema = z.object({
-  object: GitHubTagObjectSchema,
-})
-
 export const GitHubReleaseSchema = z.object({
-  name: z.string(),
+  tag_name: z.string(),
+  prerelease: z.boolean(),
 })
 
 export type GitHubReleaseType = z.infer<typeof GitHubReleaseSchema>
@@ -60,34 +57,33 @@ export class GitHubClient extends AbstractPackageClient {
       const filtered = this.showPrerelease
         ? releases
         : releases.filter((release) => {
-            const coerced = coerceUnlessValid(release.name)?.toString() ?? release.name
-            return !isPrerelease(coerced)
+            return !release.prerelease
           })
       if (filtered.length === 0) {
         throw new Error('No valid versions found')
       }
 
-      const sorted = filtered.sort((a, b) => compare(a.name, b.name))
+      const sorted = filtered.sort((a, b) => compare(a.tag_name, b.tag_name))
       return sorted[sorted.length - 1]
     }
 
-    const getTag = async (tagName: string) => {
+    const getCommit = async (tagName: string) => {
       const data = await this.fetchJson(
-        urlJoin(this.source.toString(), 'repos', repo, 'git', 'refs', 'tags', tagName),
+        urlJoin(this.source.toString(), 'repos', repo, 'commits', tagName),
         { headers },
       )
-      return GitHubTagSchema.parse(data)
+      return GitHubCommitSchema.parse(data)
     }
 
     const latest = await getLatestRelease()
-    const tag = await getTag(latest.name)
-    const version = latest.name
+    const commit = await getCommit(latest.tag_name)
+    const version = latest.tag_name
 
     return {
       name,
       version: version,
       versions: [version],
-      alias: tag.object.sha,
+      alias: commit.sha,
       format: 'github-actions-workflow',
     }
   }

--- a/src/package/github.ts
+++ b/src/package/github.ts
@@ -1,8 +1,8 @@
-import camelcaseKeys from 'camelcase-keys'
 import z from 'zod'
 
 import { PackageType } from '@/schemas'
 import { urlJoin } from '@/utils'
+import { coerceUnlessValid, compare, isPrerelease } from '@/versioning/utils'
 
 import { AbstractPackageClient } from './abstractClient'
 
@@ -14,13 +14,13 @@ export const GitHubTagSchema = z.object({
   object: GitHubTagObjectSchema,
 })
 
-export type GitHubTagType = z.infer<typeof GitHubTagSchema>
-
 export const GitHubReleaseSchema = z.object({
-  tagName: z.string(),
+  name: z.string(),
 })
 
 export type GitHubReleaseType = z.infer<typeof GitHubReleaseSchema>
+
+export const GitHubReleasesSchema = z.array(GitHubReleaseSchema)
 
 export class GitHubClient extends AbstractPackageClient {
   private gitHubPersonalAccessToken: string | undefined = undefined
@@ -50,10 +50,25 @@ export class GitHubClient extends AbstractPackageClient {
 
     const getLatestRelease = async () => {
       const data = await this.fetchJson(
-        urlJoin(this.source.toString(), 'repos', repo, 'releases', 'latest'),
-        { headers },
+        urlJoin(this.source.toString(), 'repos', repo, 'releases'),
+        {
+          headers,
+        },
       )
-      return GitHubReleaseSchema.parse(camelcaseKeys(data as object, { deep: true }))
+
+      const releases = GitHubReleasesSchema.parse(data)
+      const filtered = this.showPrerelease
+        ? releases
+        : releases.filter((release) => {
+            const coerced = coerceUnlessValid(release.name)?.toString() ?? release.name
+            return !isPrerelease(coerced)
+          })
+      if (filtered.length === 0) {
+        throw new Error('No valid versions found')
+      }
+
+      const sorted = filtered.sort((a, b) => compare(a.name, b.name))
+      return sorted[sorted.length - 1]
     }
 
     const getTag = async (tagName: string) => {
@@ -64,13 +79,13 @@ export class GitHubClient extends AbstractPackageClient {
       return GitHubTagSchema.parse(data)
     }
 
-    const release = await getLatestRelease()
-    const tag = await getTag(release.tagName)
-    const version = release.tagName
+    const latest = await getLatestRelease()
+    const tag = await getTag(latest.name)
+    const version = latest.name
 
     return {
       name,
-      version,
+      version: version,
       versions: [version],
       alias: tag.object.sha,
       format: 'github-actions-workflow',


### PR DESCRIPTION
I noticed there is a glitch in the latest approach (use `GET /repos/{owner}/{repo}/releases/latest`) while testing #180.

The latest is:

```js
  "tag_name": "codeql-bundle-v2.25.4",
  "target_commitish": "main",
  "name": "CodeQL Bundle v2.25.4",
```
 
But apparently it's wrong in terms of the semver's point of view.  `v4.35.4` is the latest.

This PR fixes the issue by using list releases API (`GET /repos/{owner}/{repo}/releases`) and find the latest one by sorting tag names. 

Also this PR changes to use the commit API instead of the tag API to avoid the annotated tag trap. 
